### PR TITLE
Créer des formulaires avec Symfony: Part 2: Relation multiple & imbri…

### DIFF
--- a/src/OC/PlatformBundle/Controller/AdvertController.php
+++ b/src/OC/PlatformBundle/Controller/AdvertController.php
@@ -3,6 +3,7 @@ namespace OC\PlatformBundle\Controller;
 
 use OC\PlatformBundle\Entity\Image;
 use OC\PlatformBundle\Entity\Advert;
+use OC\PlatformBundle\Form\AdvertType;
 use OC\PlatformBundle\Entity\AdvertSkill;
 use OC\PlatformBundle\Entity\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -70,48 +71,24 @@ class AdvertController extends Controller
 
     public function addAction(Request $request)
     {
-        // On crée un objet Advert
         $advert = new Advert();
-        // $advert = $this->getDoctrine()->getManager()
-        //                 ->getRepository('OCPlatformBundle:Advert')->find(14);
+        $form = $this->createForm(AdvertType::class, $advert);
+        //$form=$this->get('form.factory')->create(AdvertType::class,$advert);
 
-        // On crée le FormBuilder grâce au service form factory
-        $formBuilder = $this->get('form.factory')->createBuilder(FormType::class, $advert);
+        if ($request->isMethod('POST') && 
+            $form->handleRequest($request)->isValid()) {
 
-        // On ajoute les champs de l'entité que l'on veut à notre formulaire
-        $formBuilder
-            ->add('date',      DateType::class)
-            ->add('title',     TextType::class)
-            ->add('content',   TextareaType::class)
-            ->add('author',    TextType::class)
-            ->add('published', CheckboxType::class, [
-                'required' => false
-            ])
-            ->add('save',      SubmitType::class);
-
-        // À partir du formBuilder, on génère le formulaire
-        $form = $formBuilder->getForm();
-
-        if ($request->isMethod('POST')) {
-            // On fait le lien Requête <-> Formulaire
-            // $advert contient les valeurs entrées ds le formulaire par user
-            $form->handleRequest($request);
-
-            if ($form->isValid()) {
-                $em = $this->getDoctrine()->getManager();
-                $em->persist($advert);
-                $em->flush();
-                $request->getSession()->getFlashBag()
-                        ->add('notice', 'Annonce bien enregistrée.');
+            $em = $this->getDoctrine()->getManager();
+            $em->persist($advert);
+            $em->flush();
+            $request->getSession()->getFlashBag()
+                    ->add('notice', 'Annonce bien enregistrée.');
                 
-                return $this->redirectToRoute('oc_advert_view', [
-                    'id' => $advert->getId()
-                ]);
-            }
+            return $this->redirectToRoute('oc_advert_view', [
+                'id' => $advert->getId()
+            ]);
         }
 
-        // On passe la méthode createView() du formulaire à la vue
-        // afin qu'elle puisse afficher le formulaire toute seule
         return $this->render('@OCPlatform/Advert/add.html.twig', [
             'form' => $form->createView()
         ]);

--- a/src/OC/PlatformBundle/Form/AdvertType.php
+++ b/src/OC/PlatformBundle/Form/AdvertType.php
@@ -2,6 +2,8 @@
 
 namespace OC\PlatformBundle\Form;
 
+use OC\PlatformBundle\Form\ImageType;
+use OC\PlatformBundle\Form\CategoryType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -10,6 +12,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 
 class AdvertType extends AbstractType
 {
@@ -24,12 +27,19 @@ class AdvertType extends AbstractType
             ->add('author',    TextType::class)
             ->add('content',   TextareaType::class)
             ->add('published', CheckboxType::class, ['required' => false])
+            ->add('image',     ImageType::class)
+            ->add('categories', CollectionType::class, [
+                'entry_type' => CategoryType::class,
+                'allow_add' => true,
+                'allow_delete' => true
+            ])
             ->add('save',      SubmitType::class);
+            
             // ->add('updatedAt')
             // ->add('nbApplications')
             // ->add('slug')
-            // ->add('image')
-            // ->add('categories');
+            // ->add('image')           +++
+            // ->add('categories');     +++
     }
     
     /**

--- a/src/OC/PlatformBundle/Form/CategoryType.php
+++ b/src/OC/PlatformBundle/Form/CategoryType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OC\PlatformBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class CategoryType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('name', TextType::class);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => 'OC\PlatformBundle\Entity\Category'
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'oc_platformbundle_category';
+    }
+
+
+}

--- a/src/OC/PlatformBundle/Form/ImageType.php
+++ b/src/OC/PlatformBundle/Form/ImageType.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace OC\PlatformBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class ImageType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('url', TextType::class)
+            ->add('alt', TextType::class);
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => 'OC\PlatformBundle\Entity\Image'
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'oc_platformbundle_image';
+    }
+
+
+}

--- a/src/OC/PlatformBundle/Resources/views/Advert/form.html.twig
+++ b/src/OC/PlatformBundle/Resources/views/Advert/form.html.twig
@@ -50,6 +50,10 @@
 
         {# {{ form_row(form.author) }} #}
         {{ form_row(form.published) }}
+        {{ form_row(form.image) }}
+
+        {{ form_row(form.categories) }}
+        <a href="#" id="add_category" class="btn btn-default">Ajouter une catégorie</a>
 
         {# Pr le bouton, pas de label ni erreur, on affiche juste le widget #}
         {{ form_widget(form.save, {'attr': {'class': 'btn btn-primary'}}) }}
@@ -60,5 +64,73 @@
 
         {# Fermeture de la balise <form> du formulaire HTML #}
         {{ form_end(form) }}
-
 </div>
+
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+
+<script type="text/javascript">
+$(document).ready(function() {
+    // On récupère la balise <div> en question qui contient l'attribut « data-prototype » qui nous intéresse.
+    var $container = $('div#oc_platformbundle_advert_categories');
+
+    // créer 1 compteur unique pr nommer les champs q'on va ajouter dynamiqmt
+    var index = $container.find(':input').length;
+
+    // On ajoute un nouveau champ à chaque clic sur le lien d'ajout.
+    $('#add_category').click(function(e) {
+      addCategory($container);
+
+      e.preventDefault(); // évite qu'un # apparaisse dans l'URL
+      return false;
+    });
+
+    // On ajoute un premier champ automatiquement s'il n'en existe pas déjà un (cas d'une nouvelle annonce par exemple).
+    if (index == 0) {
+      addCategory($container);
+    } else {
+      // S'il existe déjà des catégories, on ajoute un lien de suppression pour chacune d'entre elles
+      $container.children('div').each(function() {
+        addDeleteLink($(this));
+      });
+    }
+
+    // La fonction qui ajoute un formulaire CategoryType
+    function addCategory($container) {
+      // Dans le contenu de l'attribut « data-prototype », on remplace :
+      // - le texte "__name__label__" qu'il contient par le label du champ
+      // - le texte "__name__" qu'il contient par le numéro du champ
+      var template = $container.attr('data-prototype')
+        .replace(/__name__label__/g, 'Catégorie n°' + (index+1))
+        .replace(/__name__/g, index);
+
+      // On crée un objet jquery qui contient ce template
+      var $prototype = $(template);
+
+      // On ajoute au prototype un lien pour pouvoir supprimer la catégorie
+      addDeleteLink($prototype);
+
+      // On ajoute le prototype modifié à la fin de la balise <div>
+      $container.append($prototype);
+
+      // Enfin, on incrémente le compteur pour que le prochain ajout se fasse avec un autre numéro
+      index++;
+    }
+
+    // La fonction qui ajoute un lien de suppression d'une catégorie
+    function addDeleteLink($prototype) {
+      // Création du lien
+      var $deleteLink = $('<a href="#" class="btn btn-danger">Supprimer</a>');
+
+      // Ajout du lien
+      $prototype.append($deleteLink);
+
+      // Ajout du listener sur le clic du lien pour effectivement supprimer la catégorie
+      $deleteLink.click(function(e) {
+        $prototype.remove();
+
+        e.preventDefault(); // évite qu'un # apparaisse dans l'URL
+        return false;
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
Créer des formulaires avec Symfony: Part 2: Relation multiple & imbriquer un même forumalaire plusieurs fois (ajax)

Relation multiple : imbriquer un même formulaire plusieurs fois

Utilisation de JQuery pour créer dynamiquement les champs catégories directement dans le template form.html.twig : 
<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
<script type="text/javascript">
     $(document).ready(function() { ... }
</script>