### PR TITLE
Créer des formulaires avec Symfony: Part 4: Héritage de formulaire (g…

### DIFF
--- a/src/OC/PlatformBundle/Controller/AdvertController.php
+++ b/src/OC/PlatformBundle/Controller/AdvertController.php
@@ -6,6 +6,7 @@ use OC\PlatformBundle\Entity\Advert;
 use OC\PlatformBundle\Form\AdvertType;
 use OC\PlatformBundle\Entity\AdvertSkill;
 use OC\PlatformBundle\Entity\Application;
+use OC\PlatformBundle\Form\AdvertEditType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -99,6 +100,7 @@ class AdvertController extends Controller
     {
         $em = $this->getDoctrine()->getManager();
         $advert = $em->getRepository('OCPlatformBundle:Advert')->find($id);
+        $form = $this->createForm(AdvertEditType::class, $advert);
 
         if (null === $advert) {
             throw new NotFoundHttpException("L'annonce d'id ".$id." n'existe pas.");
@@ -114,6 +116,7 @@ class AdvertController extends Controller
         }
 
         return $this->render('@OCPlatform/Advert/edit.html.twig', [
+            'form' => $form->createView(),
             'advert' => $advert
         ]);
     }

--- a/src/OC/PlatformBundle/Entity/Category.php
+++ b/src/OC/PlatformBundle/Entity/Category.php
@@ -29,6 +29,16 @@ class Category
      */
     private $name;
 
+    /**
+     * @var string
+     */
+    private $display;
+
+
+    public function getDisplay()
+    {
+        return $this->id.'-'.$this->name;
+    }
 
     /**
      * Get id

--- a/src/OC/PlatformBundle/Form/AdvertEditType.php
+++ b/src/OC/PlatformBundle/Form/AdvertEditType.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace OC\PlatformBundle\Form;
+
+use OC\PlatformBundle\Form\ImageType;
+// use OC\PlatformBundle\Form\AdvertType;
+use OC\PlatformBundle\Form\CategoryType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use OC\PlatformBundle\Repository\CategoryRepository;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+
+class AdvertEditType extends AbstractType
+{
+    public function getParent()
+    {
+        return AdvertType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->remove('date');
+    }
+    
+
+    /* On Supprime toutes cette partie qui ne sert à rien */
+
+    // /**
+    //  * {@inheritdoc}
+    //  */
+    // public function configureOptions(OptionsResolver $resolver)
+    // {
+    //     $resolver->setDefaults(array(
+    //         'data_class' => 'OC\PlatformBundle\Entity\Advert'
+    //     ));
+    // }
+
+    // /**
+    //  * {@inheritdoc}
+    //  */
+    // public function getBlockPrefix()
+    // {
+    //     return 'oc_platformbundle_advert';
+    // }
+
+
+}

--- a/src/OC/PlatformBundle/Form/AdvertType.php
+++ b/src/OC/PlatformBundle/Form/AdvertType.php
@@ -24,7 +24,7 @@ class AdvertType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         // Arbitrairemt, on récupère ts les catégorie qui commencent par "D"
-        $pattern = 'G%';
+        $pattern = 'D%';
 
         $builder
             ->add('date',      DateTimeType::class)
@@ -35,9 +35,9 @@ class AdvertType extends AbstractType
             ->add('image',     ImageType::class)
             ->add('categories', EntityType::class, [
                 'class' => 'OCPlatformBundle:Category',
-                'choice_label'  => 'name',
+                'choice_label'  => 'display',
                 'multiple'      => true,
-                'expanded'      => false,
+                'expanded'      => false, /* Liste */
                 'query_builder' => function(CategoryRepository $repository) use($pattern) {
                     return $repository->getLikeQueryBuilder($pattern);
                   }

--- a/src/OC/PlatformBundle/Resources/views/Advert/form.html.twig
+++ b/src/OC/PlatformBundle/Resources/views/Advert/form.html.twig
@@ -9,7 +9,9 @@
         {{ form_errors(form) }}
 
         {# Génération du label + error + widget pour un champ. #}
-        {{ form_row(form.date) }}
+        {% if form.date is defined %}
+          {{ form_row(form.date) }}
+        {% endif %}
 
         {# Génération manuelle et éclatée:  #}
         <div class="form-group">


### PR DESCRIPTION
…etParent())

*** dans le AdvertEditType: on met une méthode qui permet d'hériter de tous les champs du parent 

     public function getParent()
     {
          return AdvertType::class;
     }

*** et on Supprime ou ajoute ce qu'on veut
     $builder->remove('date');