### PR TITLE
Sécurité et gestion des utilisateurs: Part 2: Gestion des autorisatio…

### DIFF
--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -33,8 +33,15 @@
       <div id="menu" class="col-md-3">
         <h3>Les annonces</h3>
         <ul class="nav nav-pills nav-stacked">
+          
           <li><a href="{{ path('oc_advert_home') }}">Accueil</a></li>
-          <li><a href="{{ path('oc_advert_add') }}">Ajouter une annonce</a></li>
+
+          {# On n'affiche le lien « Ajouter une annonce » qu'aux auteurs
+          (et admins, qui héritent du rôle auteur) #}
+          {% if is_granted('ROLE_USER') %}
+            <li><a href="{{ path('oc_advert_add') }}">Ajouter une annonce</a></li>
+          {% endif %}
+          
         </ul>
 
         <h4>Dernières annonces</h4>

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -4,8 +4,9 @@ security:
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext
 
-    role_hierarchy:
-        ROLE_ADMIN: ROLE_USER
+    # Hiérarchie des rôles uniquement et non l'exhaustivité
+    role_hierarchy:  
+        ROLE_ADMIN: ROLE_USER, ROLE_AUTEUR, ROLE_MODERATEUR
         ROLE_SUPER_ADMIN: [ROLE_USER, ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH]
 
     # https://symfony.com/doc/current/security.html#b-configuring-how-users-are-loaded
@@ -50,4 +51,8 @@ security:
             #form_login: ~
 
     access_control:
+        - { path: ^/admin, roles: ROLE_ADMIN }
+
+        # permet é=mnt de sécuriser vos URL par IP ou canal (http ou https),
+        # - { path: ^/admin, ip: 127.0.0.1, requires_channel: https }
         # - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https }

--- a/src/OC/PlatformBundle/Controller/AdvertController.php
+++ b/src/OC/PlatformBundle/Controller/AdvertController.php
@@ -17,7 +17,9 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class AdvertController extends Controller
 {
@@ -70,8 +72,19 @@ class AdvertController extends Controller
             ]);
     }
 
+    /**
+     * 2- deuxième méthode pour vérifier l'autorisation user (2/4)
+     * 
+     * @Security("has_role('ROLE_AUTEUR')")
+     */
     public function addAction(Request $request)
     {
+        // 1-On vérifie si l'user dispose du rôle ROLE_AUTEUR
+        if (!$this->get('security.authorization_checker')->isGranted('ROLE_AUTEUR')) {
+            // Sinon on déclenche une exception <<Accès Interdit>>
+            throw new AccessDeniedException('Accès limité aux auteurs.');
+        }
+
         $advert = new Advert();
         $form = $this->createForm(AdvertType::class, $advert);
         //$form=$this->get('form.factory')->create(AdvertType::class,$advert);


### PR DESCRIPTION
…ns avec les Rôles

*** role_hierarchy :  On définit ici uniquement la hiérarchie entre les rôles, et non l'exhaustivité des rôles. Ainsi, on pourrait tout à fait avoir un rôle ROLE_TRUC dans notre application, mais que les administrateurs n'héritent pas.

*** Tester les rôles de l'utiliisateur :  Il existe quatre méthodes pour faire ce test : 
- les annotations, 
- le service security.authorization_checker, 
- Twig, 
- et les contrôles d'accès (fichier app/config/security.yml). 
     access_control:
        - { path: ^/admin, roles: ROLE_ADMIN }   ou 
        - { path: ^/admin, ip: 127.0.0.1, requires_channel: https }
        - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY, requires_channel: https } 