### PR TITLE
 Bloc-29: Traduire son site avec Symfony (dictionnaire=Catalogue Symf…

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -89,3 +89,9 @@ fos_user:
     from_email:
         address:     "%mailer_user%"
         sender_name: "toure"
+
+services:
+    twig.extension.intl:
+        class: Twig_Extensions_Extension_Intl
+        tags:
+            - { name: twig.extension }

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,6 +1,8 @@
 oc_platform:
     resource: "@OCPlatformBundle/Resources/config/routing.yml"
-    prefix:   /advert
+    prefix:   /{_locale}/advert
+    requirements:
+        _locale: en|fr
 
 app:
     resource: '@AppBundle/Controller/'

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -12,3 +12,8 @@ _errors:
 
 _main:
     resource: routing.yml
+
+oc_platform_translation:
+    path: /{_locale}/traduction/{name}
+    defaults:
+        _controller: OCPlatformBundle:Advert:translation

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "symfony/polyfill-apcu": "^1.0",
         "symfony/swiftmailer-bundle": "^2.6.4",
         "symfony/symfony": "3.4.*",
-        "twig/twig": "^1.0||^2.0"
+        "twig/twig": "^1.0||^2.0",
+        "twig/extensions": "~1.3"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72a24d830dda871ddd1205ef7bb87c67",
+    "content-hash": "ad6ccdfad30ca475fd49802f4ae92014",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2646,6 +2646,61 @@
                 "framework"
             ],
             "time": "2019-12-01T13:50:53+00:00"
+        },
+        {
+            "name": "twig/extensions",
+            "version": "v1.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig-extensions.git",
+                "reference": "57873c8b0c1be51caa47df2cdb824490beb16202"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/57873c8b0c1be51caa47df2cdb824490beb16202",
+                "reference": "57873c8b0c1be51caa47df2cdb824490beb16202",
+                "shasum": ""
+            },
+            "require": {
+                "twig/twig": "^1.27|^2.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.4",
+                "symfony/translation": "^2.7|^3.4"
+            },
+            "suggest": {
+                "symfony/translation": "Allow the time_diff output to be translated"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_Extensions_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\Extensions\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Common additional features for Twig that do not directly belong in core",
+            "keywords": [
+                "i18n",
+                "text"
+            ],
+            "time": "2018-12-05T18:34:18+00:00"
         },
         {
             "name": "twig/twig",

--- a/src/OC/PlatformBundle/Controller/AdvertController.php
+++ b/src/OC/PlatformBundle/Controller/AdvertController.php
@@ -198,6 +198,13 @@ class AdvertController extends Controller
           );
     }
 
+    public function translationAction($name)
+    {
+        return $this->render('@OCPlatform/Advert/translation.html.twig', [
+            'name' => $name
+        ]);
+    }
+
 
     // *** MES  TESTS *************************
     public function listAction()

--- a/src/OC/PlatformBundle/Resources/translations/messages.de.yml
+++ b/src/OC/PlatformBundle/Resources/translations/messages.de.yml
@@ -1,0 +1,3 @@
+# src/OC/PlatformBundle/Resources/translations/messages.fr.yml
+
+Hello: Guten Tag

--- a/src/OC/PlatformBundle/Resources/translations/messages.en.yml
+++ b/src/OC/PlatformBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,6 @@
+# src/OC/PlatformBundle/Resources/translations/messages.fr.yml
+
+# La syntaxe est : « la chaîne source: la chaîne cible »
+Symfony is great: J'aime Symfony
+Hello: Hello %name%!
+Bye: Au revoir

--- a/src/OC/PlatformBundle/Resources/translations/messages.fr.yml
+++ b/src/OC/PlatformBundle/Resources/translations/messages.fr.yml
@@ -1,0 +1,6 @@
+# src/OC/PlatformBundle/Resources/translations/messages.fr.yml
+
+# La syntaxe est : « la chaîne source: la chaîne cible »
+Symfony is great: J'aime Symfony
+Hello: Bonjour %name% !
+Bye: Au revoir

--- a/src/OC/PlatformBundle/Resources/views/Advert/translation.html.twig
+++ b/src/OC/PlatformBundle/Resources/views/Advert/translation.html.twig
@@ -1,0 +1,10 @@
+{# src/OC/PlatformBundle/Resources/views/Advert/translation.html.twig #}
+
+<html>
+  <body>
+  <br><br>
+    {{ 'Hello'|trans({ '%name%': name }) }}
+
+    <p>Aujourd'hui nous sommes le {{ 'now'|localizeddate('full', 'none') }} et il est {{ 'now'|localizeddate('none', 'short') }}</p>
+  </body>
+</html>


### PR DESCRIPTION
…noy)
***La méthodologie d'une traduction est la suivante :
** Détermination du texte à traduire : cela se fait grâce à la balise et au filtre Twig, ou directement grâce au service translator ;
** Détermination de la langue cible : cela s'obtient avec la locale, que Symfony définit soit à partir de l'URL, soit à partir des préférences de l'internaute.

*** Traduction à l'aide d'un dictionnaire : cela correspond aux catalogues dans Symfony ;

*** Il existe plusieurs formats possibles pour les catalogues, le YAML étant le plus simple ;

*** Il existe différentes méthodes pour bien organiser ses catalogues, pensez-y !

*** Il est possible de faire varier les traductions en fonction de paramètres et/ou de pluriels.