### PR TITLE
Bloc-31: Personnaliser les pages d'erreur

### DIFF
--- a/app/Resources/TwigBundle/views/Exception/error.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error.html.twig
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>An Error Occurred: {{ status_text }}</title>
+  </head>
+  <body>
+    <h1>Oops! An Error Occurred</h1>
+    <h2>The server returned a "{{ status_code }} {{ status_text }}".</h2>
+
+    <div>
+      Something is broken. Please e-mail us at [email] and let us know
+      what you were doing when this error occurred. We will fix it as soon
+      as possible. Sorry for any inconvenience caused.
+    </div>
+  </body>
+</html>

--- a/app/Resources/TwigBundle/views/Exception/error404.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error404.html.twig
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>An Error Occurred: {{ status_text }}</title>
+  </head>
+  <body>
+    <h1>Oops! An Error Occurred</h1>
+    <h2>The server returned a "{{ status_code }} {{ status_text }}".</h2>
+
+    <div>
+      Something is broken. Please e-mail us at [email] and let us know
+      what you were doing when this error occurred. We will fix it as soon
+      as possible. Sorry for any inconvenience caused.
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
*** Modifier les vues d'un bundle quelconque est très pratique, votre site garde ainsi une cohérence dans son design, et ce, que ce soit sur votre bundle à vous comme sur les autres ;

*** Personnaliser les pages d'erreur, ce n'est pas la priorité lorsque l'on démarre un projet Symfony, mais c'est impératif avant de l'ouvrir à nos visiteurs.